### PR TITLE
Fix shebang

### DIFF
--- a/gh-actuse
+++ b/gh-actuse
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 declare repo_total_ms
 declare org_total_ms
 declare org_total_repos


### PR DESCRIPTION
Not all distros provide bash in /bin/bash.

That's a common issue with non FHS compliant distros like NixOS.

It's a simple fix, but it's the difference between not working at all and working nicely.
